### PR TITLE
log TableName and RequestId with errors

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -250,9 +250,15 @@ class Connection(object):
                 code = code.rsplit('#', 1)[1]
             botocore_expected_format = {'Error': {'Message': data.get('message', ''), 'Code': code}}
             verbose_properties = {
-                'table_name': operation_kwargs.get('TableName'),
-                'request_id': response.headers.get('x-amzn-RequestId'),
+                'request_id': response.headers.get('x-amzn-RequestId')
             }
+
+            if 'RequestItems' in operation_kwargs:
+                # Batch operations can hit multiple tables, report them comma separated
+                verbose_properties['table_name'] = ','.join(operation_kwargs['RequestItems'])
+            else:
+                verbose_properties['table_name'] = operation_kwargs.get('TableName')
+
             raise VerboseClientError(botocore_expected_format, operation_name, verbose_properties)
         data = response.json()
         # Simulate botocore's binary attribute handling

--- a/pynamodb/exceptions.py
+++ b/pynamodb/exceptions.py
@@ -2,6 +2,8 @@
 PynamoDB exceptions
 """
 
+import botocore.exceptions
+
 
 class PynamoDBException(Exception):
     """
@@ -83,3 +85,19 @@ class TableDoesNotExist(PynamoDBException):
     def __init__(self, table_name):
         msg = "Table does not exist: `{0}`".format(table_name)
         super(TableDoesNotExist, self).__init__(msg)
+
+
+class VerboseClientError(botocore.exceptions.ClientError):
+    def __init__(self, error_response, operation_name, verbose_properties=None):
+        """ Modify the message template to include the desired verbose properties """
+        if not verbose_properties:
+            verbose_properties = {}
+
+        self.MSG_TEMPLATE = (
+            'An error occurred ({{error_code}}) on request ({request_id}) '
+            'on table ({table_name}) when calling the {{operation_name}} '
+            'operation: {{error_message}}'
+        ).format(request_id=verbose_properties.get('request_id'), table_name=verbose_properties.get('table_name'))
+
+        super(VerboseClientError, self).__init__(error_response, operation_name)
+


### PR DESCRIPTION
Example:

> `pynamodb.exceptions.PutError: Failed to put item: An error occurred (ConditionalCheckFailedException) on request (ee416189-1e4f-4911-aef3-1db0a835adf9) on table (MyTable) when calling the PutItem operation: The conditional request failed`